### PR TITLE
Fix the visibility of the waves on light backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SiriWave
+# siri_wave
 
 [![pub package](https://img.shields.io/pub/v/siri_wave.svg?style=for-the-badge)](https://pub.dev/packages/siri_wave)
 [![Platform](https://img.shields.io/badge/Platform-Flutter-02569B?logo=flutter&style=for-the-badge)](https://flutter.dev)
@@ -41,7 +41,7 @@ class MyWidget extends StatelessWidget {
 }
 ```
 
-To be able to change the `amplitude`, `frequency`, `speed` and `color` of the waveform, create a `SiriWaveController` and pass it to the `SiriWave` widget:
+To be able to change the `amplitude`, `frequency`, `speed` and `color` properties of the waveform, create a `SiriWaveController` and pass it to the `SiriWave` widget:
 
 ```dart
 import 'package:siri_wave/siri_wave.dart';
@@ -56,7 +56,6 @@ class MyWidget extends StatelessWidget {
     //    speed: 0.15,
     //  );
     final controller = SiriWaveController();
-
     return SiriWave(controller: controller);
   }
 }
@@ -68,7 +67,7 @@ And then call any method you want from the controller.
 controller.setAmplitude(0.8);
 controller.setSpeed(0.1);
 
-// Only available in iOS 7 style waveform.
+// Only available in the iOS 7 style waveform.
 controller.setColor(Colors.yellow);
 controller.setFrequency(4);
 ```
@@ -102,11 +101,11 @@ See the [example](https://github.com/halildurmus/siri_wave/blob/main/example/lib
 
 ## SiriWaveOptions
 
-| Parameter          | Type     | Description                              | Default       |
-| ------------------ | -------- | ---------------------------------------- | ------------- |
-| `backgroundColor`  | Color    | The background color of the waveform.    | Colors.black  |
-| `height`           | double   | The height of the waveform.              | 180           |
-| `width`            | double   | The width of the waveform.               | 360           |
+| Parameter          | Type     | Description                                         | Default       |
+| ------------------ | -------- | ----------------------------------------------------| ------------- |
+| `height`           | double   | The height of the waveform.                         | 180           |
+| `showSupportBar`   | bool     | Whether to show support bar on iOS 9 style waveform.| true          |
+| `width`            | double   | The width of the waveform.                          | 360           |
 
 ## 🤝 Contributing
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,6 +16,14 @@ class MyApp extends StatelessWidget {
       darkTheme: ThemeData(
         brightness: Brightness.dark,
         primarySwatch: Colors.amber,
+        switchTheme: SwitchThemeData(
+            thumbColor: MaterialStateProperty.all(Colors.amber),
+            trackColor: MaterialStateProperty.resolveWith((states) {
+              if (states.contains(MaterialState.selected)) {
+                return Colors.amber.shade300;
+              }
+              return Colors.grey.withOpacity(.5);
+            })),
       ),
       themeMode: ThemeMode.dark,
       title: 'Siri Wave Demo',
@@ -33,6 +41,7 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   var _amplitude = 1.0;
   var _frequency = 6.0;
+  var _showSupportBar = true;
   var _speed = .2;
   final _isSelected = [false, true];
   final _controller = SiriWaveController();
@@ -101,6 +110,36 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
+  Widget _buildShowSupportBarSwitch() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Switch(
+        value: _showSupportBar,
+        onChanged: (value) {
+          _showSupportBar = value;
+          setState(() {});
+        },
+      ),
+    );
+  }
+
+  Widget _buildShowSupportBarSection() {
+    return AnimatedSize(
+      curve: Curves.fastOutSlowIn,
+      duration: const Duration(milliseconds: 400),
+      child: _isSelected[1]
+          ? Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('Show support bar',
+                    style: Theme.of(context).textTheme.titleMedium),
+                _buildShowSupportBarSwitch(),
+              ],
+            )
+          : const SizedBox(),
+    );
+  }
+
   Widget _buildFrequencySection() {
     return AnimatedSize(
       curve: Curves.fastOutSlowIn,
@@ -108,7 +147,8 @@ class _HomePageState extends State<HomePage> {
       child: _isSelected[0]
           ? Column(
               children: [
-                Text('Frequency', style: Theme.of(context).textTheme.headline6),
+                Text('Frequency',
+                    style: Theme.of(context).textTheme.titleLarge),
                 _buildFrequencySlider(),
               ],
             )
@@ -122,10 +162,10 @@ class _HomePageState extends State<HomePage> {
         context: context,
         builder: (context) {
           return AlertDialog(
-            titlePadding: const EdgeInsets.all(0.0),
-            contentPadding: const EdgeInsets.all(0.0),
-            shape: const RoundedRectangleBorder(
-              borderRadius: BorderRadius.all(Radius.circular(9)),
+            titlePadding: EdgeInsets.zero,
+            contentPadding: EdgeInsets.zero,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(9),
             ),
             content: SingleChildScrollView(
               child: ColorPicker(
@@ -134,9 +174,7 @@ class _HomePageState extends State<HomePage> {
                 pickerAreaHeightPercent: .7,
                 displayThumbColor: true,
                 paletteType: PaletteType.hsl,
-                pickerAreaBorderRadius: const BorderRadius.all(
-                  Radius.circular(8),
-                ),
+                pickerAreaBorderRadius: BorderRadius.circular(8),
               ),
             ),
           );
@@ -152,7 +190,7 @@ class _HomePageState extends State<HomePage> {
               children: [
                 Text(
                   'Wave Color',
-                  style: Theme.of(context).textTheme.headline6,
+                  style: Theme.of(context).textTheme.titleLarge,
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 15),
@@ -171,19 +209,18 @@ class _HomePageState extends State<HomePage> {
     return ToggleButtons(
       onPressed: (index) {
         if (_isSelected[index]) return;
-
         for (var i = 0; i < _isSelected.length; i++) {
           _isSelected[i] = i == index;
         }
         setState(() {});
       },
-      isSelected: _isSelected,
       borderColor: Theme.of(context).primaryColorLight,
       borderRadius: BorderRadius.circular(16),
+      isSelected: _isSelected,
       selectedBorderColor: Theme.of(context).colorScheme.primary,
       children: const [
-        Padding(padding: EdgeInsets.all(16), child: Text('iOS 7 Siri Wave')),
-        Padding(padding: EdgeInsets.all(16), child: Text('iOS 9 Siri Wave')),
+        Padding(padding: EdgeInsets.all(16), child: Text('iOS 7 Style')),
+        Padding(padding: EdgeInsets.all(16), child: Text('iOS 9 Style')),
       ],
     );
   }
@@ -204,36 +241,15 @@ class _HomePageState extends State<HomePage> {
         _buildDivider(),
         SiriWave(
           controller: _controller,
-          options: const SiriWaveOptions(
+          options: SiriWaveOptions(
             height: kIsWeb ? 300 : 180,
+            showSupportBar: _showSupportBar,
             width: kIsWeb ? 600 : 360,
           ),
           style: _isSelected[0] ? SiriWaveStyle.ios_7 : SiriWaveStyle.ios_9,
         ),
         _buildDivider(),
       ],
-    );
-  }
-
-  Widget _buildBody() {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Spacer(),
-          Text('Amplitude', style: Theme.of(context).textTheme.headline6),
-          _buildAmplitudeSlider(),
-          Text('Speed', style: Theme.of(context).textTheme.headline6),
-          _buildSpeedSlider(),
-          _buildFrequencySection(),
-          _buildWaveColorSection(),
-          Text('Style', style: Theme.of(context).textTheme.headline6),
-          const SizedBox(height: 15),
-          _buildToggleButtons(),
-          const Spacer(),
-          _buildSiriWave(),
-        ],
-      ),
     );
   }
 
@@ -244,8 +260,26 @@ class _HomePageState extends State<HomePage> {
         centerTitle: kIsWeb,
         title: const Text('Siri Wave Demo'),
       ),
-      backgroundColor: Colors.black,
-      body: _buildBody(),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Spacer(),
+            Text('Amplitude', style: Theme.of(context).textTheme.titleLarge),
+            _buildAmplitudeSlider(),
+            Text('Speed', style: Theme.of(context).textTheme.titleLarge),
+            _buildSpeedSlider(),
+            _buildShowSupportBarSection(),
+            _buildFrequencySection(),
+            _buildWaveColorSection(),
+            Text('Style', style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 15),
+            _buildToggleButtons(),
+            const Spacer(),
+            _buildSiriWave(),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,42 +5,48 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -52,14 +58,16 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_colorpicker
-      url: "https://pub.dartlang.org"
+      sha256: "458a6ed8ea480eb16ff892aedb4b7092b2804affd7e046591fb03127e8d8ef8b"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   flutter_lints:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -67,48 +75,61 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5cfd6509652ff5e7fe149b6df4859e687fca9048437857cb2e65c8d780f396e3"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.14"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   siri_wave:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.3.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -118,51 +139,58 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.18"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"
   flutter: ">=3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/lib/src/ios_7/ios_7_siri_wave.dart
+++ b/lib/src/ios_7/ios_7_siri_wave.dart
@@ -20,8 +20,8 @@ class IOS7SiriWaveState extends State<IOS7SiriWave>
   void initState() {
     _animationController = AnimationController(
       vsync: this,
-      // Since we don't use AnimationController's value in the animation,
-      // the duration value does not have any affect on the animation.
+      // Since AnimationController's value is not used in the animation, the
+      // duration value does not have any affect on the animation.
       duration: const Duration(seconds: 1),
     );
 

--- a/lib/src/ios_7/ios_7_siri_wave_painter.dart
+++ b/lib/src/ios_7/ios_7_siri_wave_painter.dart
@@ -5,7 +5,7 @@ import 'package:flutter/rendering.dart';
 
 import '../models/siri_wave_controller.dart';
 
-// Describes the curve properties will be used by `IOS7SiriWavePainter`.
+/// Describes the curve properties will be used by [IOS7SiriWavePainter].
 class _IOS7SiriWaveCurve {
   const _IOS7SiriWaveCurve({
     required this.attenuation,

--- a/lib/src/ios_9/ios_9_siri_wave.dart
+++ b/lib/src/ios_9/ios_9_siri_wave.dart
@@ -1,13 +1,19 @@
 import 'package:flutter/material.dart';
 
 import '../models/siri_wave_controller.dart';
+import '../models/siri_wave_options.dart';
 import 'ios_9_siri_wave_painter.dart';
 import 'support_line_painter.dart';
 
 class IOS9SiriWave extends StatefulWidget {
-  const IOS9SiriWave({super.key, required this.controller});
+  const IOS9SiriWave({
+    super.key,
+    required this.controller,
+    this.options = const SiriWaveOptions(),
+  });
 
   final SiriWaveController controller;
+  final SiriWaveOptions options;
 
   @override
   IOS9SiriWaveState createState() => IOS9SiriWaveState();
@@ -21,8 +27,8 @@ class IOS9SiriWaveState extends State<IOS9SiriWave>
   void initState() {
     _animationController = AnimationController(
       vsync: this,
-      // Since we don't use AnimationController's value in the animation,
-      // the duration value does not have any affect on the animation.
+      // Since AnimationController's value is not used in the animation, the
+      // duration value does not have any affect on the animation.
       duration: const Duration(seconds: 1),
     );
     if (widget.controller.amplitude > 0 && widget.controller.speed > 0) {
@@ -60,8 +66,8 @@ class IOS9SiriWaveState extends State<IOS9SiriWave>
     return AnimatedBuilder(
       animation: _animationController,
       builder: (_, __) => CustomPaint(
-        painter: supportLinePainter,
         foregroundPainter: widget.controller.amplitude > 0 ? wavePainter : null,
+        painter: widget.options.showSupportBar ? supportLinePainter : null,
       ),
     );
   }

--- a/lib/src/ios_9/ios_9_siri_wave_painter.dart
+++ b/lib/src/ios_9/ios_9_siri_wave_painter.dart
@@ -144,6 +144,9 @@ class IOS9SiriWavePainter extends CustomPainter {
     // Interpolate amplitude and speed values.
     controller.lerp();
 
+    canvas.saveLayer(Rect.fromLTWH(0, 0, size.width, size.height),
+        Paint()..color = Colors.white);
+
     for (final entry in _waves.entries) {
       final wave = entry.value;
       if (wave.spawnAt == 0) {
@@ -193,6 +196,8 @@ class IOS9SiriWavePainter extends CustomPainter {
 
       wave.prevMaxY = maxY;
     }
+
+    canvas.restore();
   }
 
   @override

--- a/lib/src/ios_9/ios_9_siri_wave_painter.dart
+++ b/lib/src/ios_9/ios_9_siri_wave_painter.dart
@@ -1,11 +1,10 @@
 import 'dart:math' as math;
 
-import 'package:flutter/animation.dart' show AnimationController;
-import 'package:flutter/rendering.dart';
+import 'package:flutter/material.dart';
 
 import '../models/siri_wave_controller.dart';
 
-// Describes the curve properties will be used by `IOS7SiriWavePainter`.
+/// Describes the curve properties will be used by [IOS7SiriWavePainter].
 class _IOS9SiriWave {
   _IOS9SiriWave({required this.color});
 
@@ -69,7 +68,6 @@ class IOS9SiriWavePainter extends CustomPainter {
     final wave = _waves[key]!;
     wave.phases[ci] = 0;
     wave.amplitudes[ci] = 0;
-
     wave.despawnTimeouts[ci] =
         _getRandomRange(_despawnTimeoutRanges).toDouble();
     wave.offsets[ci] = _getRandomRange(_offsetRanges).toDouble();
@@ -83,7 +81,6 @@ class IOS9SiriWavePainter extends CustomPainter {
 
   void _spawn(String key) {
     final curvesCount = _getRandomRange(_noOfCurvesRanges).floor();
-
     final wave = _waves[key]!
       ..spawnAt = DateTime.now().millisecondsSinceEpoch
       ..noOfCurves = curvesCount

--- a/lib/src/models/siri_wave_controller.dart
+++ b/lib/src/models/siri_wave_controller.dart
@@ -7,7 +7,8 @@ class _Interpolation {
   double? speed;
 }
 
-/// Controls the `amplitude`, `color`, `frequency` and `speed` of the waveform.
+/// Controls the `amplitude`, `color`, `frequency` and `speed` properties of the
+/// waveform.
 class SiriWaveController {
   /// Creates a [SiriWaveController].
   SiriWaveController({
@@ -15,11 +16,10 @@ class SiriWaveController {
     this.color = Colors.white,
     this.frequency = 6,
     this.speed = .2,
-  })  : assert(amplitude >= 0 && amplitude <= 1),
+  })  : _interpolation = _Interpolation(amplitude, speed),
+        assert(amplitude >= 0 && amplitude <= 1),
         assert(frequency >= -20 && frequency <= 20),
-        assert(speed >= 0 && speed <= 1) {
-    _interpolation = _Interpolation(amplitude, speed);
-  }
+        assert(speed >= 0 && speed <= 1);
 
   /// The amplitude of the waveform.
   ///
@@ -30,7 +30,7 @@ class SiriWaveController {
 
   /// The color of the iOS 7 style waveform.
   ///
-  /// Defaults to `Colors.white`.
+  /// Defaults to [Colors.white].
   Color color;
 
   /// The frequency of the iOS 7 style waveform.
@@ -47,7 +47,7 @@ class SiriWaveController {
   /// The value must be in the `[0, 1]` range.
   double speed;
 
-  late _Interpolation _interpolation;
+  final _Interpolation _interpolation;
 
   static const _lerpSpeed = .1;
 

--- a/lib/src/models/siri_wave_options.dart
+++ b/lib/src/models/siri_wave_options.dart
@@ -6,12 +6,15 @@ class SiriWaveOptions {
   const SiriWaveOptions({
     this.backgroundColor = Colors.black,
     this.height = 180,
+    this.showSupportBar = true,
     this.width = 360,
   });
 
   /// Background color of the [SiriWave].
   ///
-  /// Defaults to `Colors.black`.
+  /// Defaults to [Colors.black].
+  @Deprecated(
+      'backgroundColor is deprecated, has no effect, and will be removed in a future version.')
   final Color backgroundColor;
 
   /// Height of the [SiriWave].
@@ -19,13 +22,17 @@ class SiriWaveOptions {
   /// Defaults to `180`.
   final double height;
 
+  /// Whether to show the support bar on iOS 9 style [SiriWave].
+  ///
+  /// Defaults to `true`.
+  final bool showSupportBar;
+
   /// Width of the [SiriWave].
   ///
   /// Defaults to `360`.
   final double width;
 
   @override
-  String toString() {
-    return 'SiriWaveOptions(backgroundColor: $backgroundColor, height: $height, width: $width)';
-  }
+  String toString() =>
+      'SiriWaveOptions(height: $height, showSupportBar: $showSupportBar, width: $width)';
 }

--- a/lib/src/siri_wave.dart
+++ b/lib/src/siri_wave.dart
@@ -11,16 +11,16 @@ class SiriWave extends StatefulWidget {
   /// Creates a Siri style waveform.
   ///
   /// The dimensions of the waveform can be configured with [options] or
-  /// wrapping the [SiriWave] with a [SizedBox] or [Container] or any other
-  /// widget that constraints it's child.
+  /// wrapping the [SiriWave] with either a [SizedBox], a [Container] or any
+  /// other widget that constraints it's child.
   ///
   /// The style of the waveform can be configured with [style].
   /// By default, iOS 9 Siri style waveform is shown.
   SiriWave({
-    super.key,
     SiriWaveController? controller,
     this.options = const SiriWaveOptions(),
     this.style = SiriWaveStyle.ios_9,
+    super.key,
   }) : _controller = controller ?? SiriWaveController();
 
   /// See [SiriWaveController].
@@ -42,7 +42,7 @@ class _SiriWaveState extends State<SiriWave> {
   void _setSiriWaveWidget() {
     _siriWave = widget.style == SiriWaveStyle.ios_7
         ? IOS7SiriWave(controller: widget._controller)
-        : IOS9SiriWave(controller: widget._controller);
+        : IOS9SiriWave(controller: widget._controller, options: widget.options);
   }
 
   @override
@@ -54,7 +54,8 @@ class _SiriWaveState extends State<SiriWave> {
   @override
   void didUpdateWidget(covariant SiriWave oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.style != widget.style) {
+    if (oldWidget.style != widget.style ||
+        oldWidget.options.showSupportBar != widget.options.showSupportBar) {
       _setSiriWaveWidget();
     }
   }
@@ -64,10 +65,7 @@ class _SiriWaveState extends State<SiriWave> {
     return SizedBox(
       height: widget.options.height,
       width: widget.options.width,
-      child: DecoratedBox(
-        decoration: BoxDecoration(color: widget.options.backgroundColor),
-        child: _siriWave,
-      ),
+      child: _siriWave,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,42 +5,48 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -52,7 +58,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -60,41 +67,54 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5cfd6509652ff5e7fe149b6df4859e687fca9048437857cb2e65c8d780f396e3"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.14"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -104,51 +124,58 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.18"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"
   flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.2.2
 repository: https://github.com/halildurmus/siri_wave
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  sdk: '>=2.17.0 <3.0.0'
+  flutter: '>=3.0.0'
 
 dependencies:
   flutter:

--- a/test/siri_wave_test.dart
+++ b/test/siri_wave_test.dart
@@ -6,7 +6,7 @@ import 'package:siri_wave/src/ios_9/ios_9_siri_wave.dart';
 
 void main() {
   group('SiriWave', () {
-    testWidgets('widget\'s properties should be set correctly', (tester) async {
+    testWidgets("widget's properties should be set correctly", (tester) async {
       // Build the SiriWave widget.
       await tester.pumpWidget(
         MaterialApp(
@@ -21,13 +21,6 @@ void main() {
 
       expect(sizedBox.height, 180);
       expect(sizedBox.width, 360);
-
-      // Find the BoxDecoration widget.
-      final boxDecoration =
-          (tester.firstWidget<DecoratedBox>(find.byType(DecoratedBox)))
-              .decoration as BoxDecoration;
-
-      expect(boxDecoration.color, Colors.black);
     });
 
     testWidgets('widget should display the IOS9SiriWave widget by default',


### PR DESCRIPTION
Fixes #3 

- Makes `SiriWave`'s background transparent -- which fixes the visibility issues in light backgrounds.
- Deprecates `SiriWaveOptions`' `backgroundColor` property.
- Adds `showSupportBar` property to `SiriWaveOptions` to show/hide the support bar on iOS 9 style waveform. By default, the support bar is shown.